### PR TITLE
Creation of OlafImageCacher struct

### DIFF
--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		7A1343AE3F91D82BB8B56479E07946E3 /* Pods-OlafImageCacher_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = DE5FCC19AB284B6A98720D978A70C8D8 /* Pods-OlafImageCacher_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		961CA8B4F31D3FAA53B94B7F5B244803 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3212113385A8FBBDB272BD23C409FF61 /* Foundation.framework */; };
 		A5823F6D2515D60B007ECBF0 /* OlafImageCacher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5823F6C2515D60B007ECBF0 /* OlafImageCacher.swift */; };
+		A5823FAF2515F9A9007ECBF0 /* UIImageView+OlafImageCacher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5823FAE2515F9A9007ECBF0 /* UIImageView+OlafImageCacher.swift */; };
 		A9413BB4950ACB14BE400AA233929B9E /* OlafImageCacher-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C882F0C8B808BC0A6BA26DB59C8971D7 /* OlafImageCacher-dummy.m */; };
 		E40D7D9C36347D43B44195C9AA215735 /* Pods-OlafImageCacher_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F27953086DB013F140E4074662F4E24E /* Pods-OlafImageCacher_Example-dummy.m */; };
 		E5DB9E48E0DE0182847A52C66FFA8810 /* OlafImageCacher-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 93B425525F0A276C3E3444168D6B6BCC /* OlafImageCacher-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -56,6 +57,7 @@
 		940CF4D350A1C4383E47988664BE7AC9 /* Pods-OlafImageCacher_Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-OlafImageCacher_Tests-dummy.m"; sourceTree = "<group>"; };
 		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		A5823F6C2515D60B007ECBF0 /* OlafImageCacher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OlafImageCacher.swift; sourceTree = "<group>"; };
+		A5823FAE2515F9A9007ECBF0 /* UIImageView+OlafImageCacher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+OlafImageCacher.swift"; sourceTree = "<group>"; };
 		AE777B618B24A81C1B9B2B3E73136D0E /* Pods-OlafImageCacher_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-OlafImageCacher_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		B06C92A2A7BD22042CD3F559216E6970 /* Pods-OlafImageCacher_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-OlafImageCacher_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
 		C25644EBFE52816D4C3DD3C66A1B9A90 /* OlafImageCacher.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; path = OlafImageCacher.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
@@ -129,9 +131,18 @@
 			name = "Development Pods";
 			sourceTree = "<group>";
 		};
+		A5823FAD2515F98E007ECBF0 /* extensions */ = {
+			isa = PBXGroup;
+			children = (
+				A5823FAE2515F9A9007ECBF0 /* UIImageView+OlafImageCacher.swift */,
+			);
+			path = extensions;
+			sourceTree = "<group>";
+		};
 		A5BC04DC2514CB9B003887E8 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				A5823FAD2515F98E007ECBF0 /* extensions */,
 				A5823F6C2515D60B007ECBF0 /* OlafImageCacher.swift */,
 			);
 			path = Sources;
@@ -396,6 +407,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				A5823FAF2515F9A9007ECBF0 /* UIImageView+OlafImageCacher.swift in Sources */,
 				A9413BB4950ACB14BE400AA233929B9E /* OlafImageCacher-dummy.m in Sources */,
 				A5823F6D2515D60B007ECBF0 /* OlafImageCacher.swift in Sources */,
 			);

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		63B3AC9F68E6D989AED277A1EA131A6E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3212113385A8FBBDB272BD23C409FF61 /* Foundation.framework */; };
 		7A1343AE3F91D82BB8B56479E07946E3 /* Pods-OlafImageCacher_Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = DE5FCC19AB284B6A98720D978A70C8D8 /* Pods-OlafImageCacher_Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		961CA8B4F31D3FAA53B94B7F5B244803 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 3212113385A8FBBDB272BD23C409FF61 /* Foundation.framework */; };
+		A5823F6D2515D60B007ECBF0 /* OlafImageCacher.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5823F6C2515D60B007ECBF0 /* OlafImageCacher.swift */; };
 		A9413BB4950ACB14BE400AA233929B9E /* OlafImageCacher-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = C882F0C8B808BC0A6BA26DB59C8971D7 /* OlafImageCacher-dummy.m */; };
 		E40D7D9C36347D43B44195C9AA215735 /* Pods-OlafImageCacher_Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = F27953086DB013F140E4074662F4E24E /* Pods-OlafImageCacher_Example-dummy.m */; };
 		E5DB9E48E0DE0182847A52C66FFA8810 /* OlafImageCacher-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 93B425525F0A276C3E3444168D6B6BCC /* OlafImageCacher-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -54,6 +55,7 @@
 		93B425525F0A276C3E3444168D6B6BCC /* OlafImageCacher-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "OlafImageCacher-umbrella.h"; sourceTree = "<group>"; };
 		940CF4D350A1C4383E47988664BE7AC9 /* Pods-OlafImageCacher_Tests-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-OlafImageCacher_Tests-dummy.m"; sourceTree = "<group>"; };
 		9D940727FF8FB9C785EB98E56350EF41 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		A5823F6C2515D60B007ECBF0 /* OlafImageCacher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OlafImageCacher.swift; sourceTree = "<group>"; };
 		AE777B618B24A81C1B9B2B3E73136D0E /* Pods-OlafImageCacher_Tests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-OlafImageCacher_Tests.debug.xcconfig"; sourceTree = "<group>"; };
 		B06C92A2A7BD22042CD3F559216E6970 /* Pods-OlafImageCacher_Example-acknowledgements.markdown */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text; path = "Pods-OlafImageCacher_Example-acknowledgements.markdown"; sourceTree = "<group>"; };
 		C25644EBFE52816D4C3DD3C66A1B9A90 /* OlafImageCacher.podspec */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; indentWidth = 2; path = OlafImageCacher.podspec; sourceTree = "<group>"; tabWidth = 2; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
@@ -130,6 +132,7 @@
 		A5BC04DC2514CB9B003887E8 /* Sources */ = {
 			isa = PBXGroup;
 			children = (
+				A5823F6C2515D60B007ECBF0 /* OlafImageCacher.swift */,
 			);
 			path = Sources;
 			sourceTree = "<group>";
@@ -322,6 +325,11 @@
 			attributes = {
 				LastSwiftUpdateCheck = 1100;
 				LastUpgradeCheck = 1100;
+				TargetAttributes = {
+					A43858EC1CD85458A70BBBC0B38EFC96 = {
+						LastSwiftMigration = 1200;
+					};
+				};
 			};
 			buildConfigurationList = 4821239608C13582E20E6DA73FD5F1F9 /* Build configuration list for PBXProject "Pods" */;
 			compatibilityVersion = "Xcode 3.2";
@@ -389,6 +397,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				A9413BB4950ACB14BE400AA233929B9E /* OlafImageCacher-dummy.m in Sources */,
+				A5823F6D2515D60B007ECBF0 /* OlafImageCacher.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -639,6 +648,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 249FA94A4F48E46FBC7E0094823F8102 /* OlafImageCacher.release.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -671,6 +681,7 @@
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 0C13A5E28C35B19F292E4DB4BF1D3C63 /* OlafImageCacher.debug.xcconfig */;
 			buildSettings = {
+				CLANG_ENABLE_MODULES = YES;
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
@@ -691,6 +702,7 @@
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VERSIONING_SYSTEM = "apple-generic";

--- a/Sources/OlafImageCacher.swift
+++ b/Sources/OlafImageCacher.swift
@@ -1,0 +1,32 @@
+//
+//  OlafImageCacher.swift
+//  OlafImageCacher
+//
+//  Created by 신한섭 on 2020/09/19.
+//
+
+import UIKit
+
+/// Struct that contains features supported by OlafImageCacher.
+/// property `base` contains the address of an object conforming to the `ViewHashImage` protocol.
+public struct OlafImageCacher<Base> {
+    
+    private let base: Base
+    public init(_ base: Base) {
+        self.base = base
+    }
+}
+
+/// A view that has an image.
+/// e.g. UIImageView, UIButton
+public protocol ViewHasImage: AnyObject {}
+
+extension ViewHasImage {
+    /// This property allows you to use the features of OlafImageCacher.
+    /// e.g. imageView.of
+    public var of: OlafImageCacher<Self> {
+        return OlafImageCacher(self)
+    }
+}
+
+extension UIImageView: ViewHasImage {}

--- a/Sources/extensions/UIImageView+OlafImageCacher.swift
+++ b/Sources/extensions/UIImageView+OlafImageCacher.swift
@@ -1,0 +1,19 @@
+//
+//  UIImageView+OlafImageCacher.swift
+//  OlafImageCacher
+//
+//  Created by 신한섭 on 2020/09/19.
+//
+
+import UIKit
+
+extension OlafImageCacher where Base: UIImageView {
+    @discardableResult
+    public func setImage(with source: URL?) -> URLSessionDownloadTask? {
+        //TODO: 1. Cache check through ImageCacher object.
+        //TODO: 2. If an image exists, it is inserted into the image of the `base` property.
+        //TODO: 3. If it does not exist, the image is retrieved from the network and inserted into the image of the `base` property after caching.
+        
+        return URLSessionDownloadTask()
+    }
+}


### PR DESCRIPTION
Creation of OlafImageCacher structure representing the functions of OlafImageCacher.
* Generic are used for extensibility.
* It will be provided through extensions to the UIImageView and UIButton class.
* After implementing the sub-elements(ImageCacher, ImageDownloader, ...) first, this structure will be implemented.